### PR TITLE
Remove loadNamespace()

### DIFF
--- a/tests/testthat/test-et.R
+++ b/tests/testthat/test-et.R
@@ -1,14 +1,12 @@
-.rx <- loadNamespace("rxode2et")
-
 for (radi in c(1, 2)) {
-  .rx$forderForceBase(switch(radi,
-                             TRUE,
-                             FALSE
-                             ))
+  forderForceBase(switch(radi,
+                         TRUE,
+                         FALSE
+  ))
   radix <- switch(radi,
                   "base::order",
                   "data.table::forder"
-                  )
+  )
 
   # context(sprintf("Test event Table et(...) sort:%s", radix))
   et <- et()


### PR DESCRIPTION
Simplify the testing code slightly.  FYI, I have confirmed that these tests replicate the tests in `rxode2`, and a PR is coming there which will remove these tests from `rxode2`.